### PR TITLE
Fix removing the old order from the pending queue.

### DIFF
--- a/univocity-trader-core/src/main/java/com/univocity/trader/Exchange.java
+++ b/univocity-trader-core/src/main/java/com/univocity/trader/Exchange.java
@@ -94,6 +94,11 @@ public interface Exchange<T, C extends AccountConfiguration<C>> {
 	PreciseCandle generatePreciseCandle(T exchangeCandle);
 
 	/**
+	 * Starts a thread that periodically sends a keep-alive message to the underlying connection.
+	 */
+    default void startKeepAlive() { }
+
+    /**
 	 * Connects to the live exchange stream to receive real time signals which will be delegated to a given {@link TickConsumer}.
 	 *
 	 * On top of the live stream, the {@link LiveTrader} will continuously check for updates on the signals of the symbols subscribed to with this method.

--- a/univocity-trader-core/src/main/java/com/univocity/trader/LiveTrader.java
+++ b/univocity-trader-core/src/main/java/com/univocity/trader/LiveTrader.java
@@ -187,6 +187,11 @@ public abstract class LiveTrader<T, C extends Configuration<C, A>, A extends Acc
 	public void run() {
 		initialize();
 		runLiveStream();
+		runKeepAlive();
+	}
+
+	private void runKeepAlive() {
+		exchange.startKeepAlive();
 	}
 
 

--- a/univocity-trader-core/src/main/java/com/univocity/trader/account/AccountManager.java
+++ b/univocity-trader-core/src/main/java/com/univocity/trader/account/AccountManager.java
@@ -763,11 +763,13 @@ public final class AccountManager implements ClientAccount, SimulatedAccountConf
 
 		if (order.isFinalized()) {
 			logOrderStatus("", order);
-			pendingOrders.remove(order);
+			pendingOrders.remove(old);
 			orderFinalized(orderManager, order, trade);
 			return order;
 		} else { // update order status
-			pendingOrders.addOrReplace(order);
+
+			pendingOrders.remove(old);
+			pendingOrders.add(order);
 		}
 
 		if (old.getExecutedQuantity() != order.getExecutedQuantity() || (isSimulated() && order instanceof DefaultOrder && ((DefaultOrder) order).hasPartialFillDetails())) {


### PR DESCRIPTION
In updateOrderStatus it eventually calls translate which creates a new Order. This however sets a new OrderId so the comparator in the SortedSet will fail to match.

It also attempts to keep the underlying connection alive to avoid timeouts.