### PR TITLE
Keep original data types in OrderExecutionLine

### DIFF
--- a/univocity-trader-core/src/main/java/com/univocity/trader/notification/NotForExport.java
+++ b/univocity-trader-core/src/main/java/com/univocity/trader/notification/NotForExport.java
@@ -1,0 +1,9 @@
+package com.univocity.trader.notification;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NotForExport {
+    // Marker interface to avoid exporting to a google sheets
+}

--- a/univocity-trader-core/src/main/java/com/univocity/trader/notification/OrderExecutionLine.java
+++ b/univocity-trader-core/src/main/java/com/univocity/trader/notification/OrderExecutionLine.java
@@ -1,11 +1,14 @@
 package com.univocity.trader.notification;
 
-import com.univocity.parsers.annotations.*;
-import com.univocity.trader.*;
-import com.univocity.trader.account.*;
-import com.univocity.trader.indicators.base.*;
+import com.univocity.parsers.annotations.Parsed;
+import com.univocity.trader.SymbolPriceDetails;
+import com.univocity.trader.account.Balance;
+import com.univocity.trader.account.Order;
+import com.univocity.trader.account.Trade;
+import com.univocity.trader.account.Trader;
+import com.univocity.trader.indicators.base.TimeInterval;
 
-import java.sql.*;
+import java.sql.Timestamp;
 
 public class OrderExecutionLine {
 
@@ -27,50 +30,37 @@ public class OrderExecutionLine {
 	Integer ticks;
 	@Parsed
 	String fundSymbol;
-	@Parsed
-	String minPrice;
-	@Parsed
-	String minChangePct;
-	@Parsed
-	String maxChangePct;
-	@Parsed
-	String maxPrice;
-	@Parsed
-	String price;
-	@Parsed
-	String averagePrice;
+
+	double minPrice;
+	double minChangePct;
+	double maxChangePct;
+	double maxPrice;
+	double price;
+	double averagePrice;
 	@Parsed
 	String priceChangePct;
-	@Parsed
-	String quantity;
+	double quantity;
 	@Parsed
 	String referenceCurrency;
 	@Parsed
 	Order.Status status;
 	@Parsed
 	Order.Type orderType;
-	@Parsed
-	String orderAmount;
-	@Parsed
-	String executedQuantity;
-	@Parsed
-	String valueTransacted;
-	@Parsed
-	String freeBalance;
-	@Parsed
-	String shortedQuantity;
-	@Parsed
-	String marginReserve;
-	@Parsed
-	String freeBalanceReferenceCurrency;
+	double orderAmount;
+	double executedQuantity;
+	double valueTransacted;
+	double freeBalance;
+	double shortedQuantity;
+	double marginReserve;
+	Double freeBalanceReferenceCurrency;
 	@Parsed
 	String estimatedProfitLossPct;
 	@Parsed
-	String profitLoss;
+	Double profitLoss;
 	@Parsed
 	String profitLossPct;
 	@Parsed
-	String profitLossReferenceCurrency;
+	Double profitLossReferenceCurrency;
 	@Parsed
 	String holdings;
 	@Parsed
@@ -79,60 +69,67 @@ public class OrderExecutionLine {
 	String orderFillPercentage;
 	@Parsed
 	Order.TriggerCondition trigger;
-	@Parsed
-	String triggerPrice;
+	double triggerPrice;
 
 	double fillPct;
 	boolean isShort;
 	boolean isBuy;
 
+	private Order order;
+	private final Trade trade;
+	private final Trader trader;
+
+
 	public OrderExecutionLine(Order order, Trade trade, Trader trader, Client client) {
 		SymbolPriceDetails priceDetails = trader.priceDetails();
 		SymbolPriceDetails refPriceDetails = trader.referencePriceDetails();
 
+		this.order = order;
+		this.trade = trade;
+		this.trader = trader;
+
 		clientId = client.getId();
 		referenceCurrency = trader.referenceCurrencySymbol();
 
-		freeBalanceReferenceCurrency = refPriceDetails.priceToString(trader.balance().getFree());
+		freeBalanceReferenceCurrency = Double.parseDouble(refPriceDetails.priceToString(trader.balance().getFree()));
 		holdings = refPriceDetails.priceToString(trader.holdings());
 
 		double priceAmount = order == null || order.getPrice() == 0.0 ? trader.latestCandle().close : order.getPrice();
 
 		if (order != null) {
-			price = priceDetails.priceToString(priceAmount);
 			fundSymbol = trader.fundSymbol();
 			closeTime = trader.latestCandle().closeTimestamp();
 			assetSymbol = trader.assetSymbol();
 
 			Balance balance = trader.balanceOf(fundSymbol);
-			shortedQuantity = priceDetails.quantityToString(trader.balance(assetSymbol).getShorted());
+			shortedQuantity = trader.balance(assetSymbol).getShorted();
 
 			SymbolPriceDetails amountDetails = fundSymbol.equals(referenceCurrency) ? refPriceDetails : priceDetails;
 
-			freeBalance = amountDetails.priceToString(balance.getFree());
-			marginReserve = amountDetails.priceToString(balance.getMarginReserve(trader.assetSymbol()));
-			valueTransacted = amountDetails.priceToString(order.getTotalTraded());
-			price = order.isBuy() ? amountDetails.priceToString(order.getPrice()) : price;
-			averagePrice = amountDetails.priceToString(order.getAveragePrice());
+			freeBalance = balance.getFree();
+			marginReserve = balance.getMarginReserve(trader.assetSymbol());
+			valueTransacted = order.getTotalTraded();
+			price = order.isBuy() ? order.getPrice() : priceAmount;
+			averagePrice = order.getAveragePrice();
 
 			orderId = order.getOrderId();
-			quantity = priceDetails.quantityToString(order.getQuantity());
+			quantity = order.getQuantity();
 			status = order.getStatus();
 			operation = order.sideDescription();
 			isShort = order.isShort();
 			isBuy = order.isBuy();
 			orderType = order.getType();
-			executedQuantity = priceDetails.quantityToString(order.getExecutedQuantity());
+			executedQuantity = order.getExecutedQuantity();
 			fillPct = order.getFillPct();
 			orderFillPercentage = order.getFormattedFillPct();
 
 			if (orderType == Order.Type.MARKET && fillPct == 0.0) {
-				orderAmount = amountDetails.priceToString(order.getQuantity() * trader.lastClosingPrice());
+				orderAmount = order.getQuantity() * trader.lastClosingPrice();
 			} else {
-				orderAmount = amountDetails.priceToString(order.getTotalOrderAmount());
+				orderAmount = order.getTotalOrderAmount();
 			}
 			this.trigger = order.getTriggerCondition();
-			this.triggerPrice = priceDetails.priceToString(order.getTriggerPrice());
+			this.triggerPrice = order.getTriggerPrice();
 		} else {
 			operation = "END";
 		}
@@ -140,14 +137,14 @@ public class OrderExecutionLine {
 			tradeId = trade.id();
 			priceChangePct = trade.formattedPriceChangePct();
 			if (trade.isFinalized()) {
-				profitLoss = priceDetails.priceToString(trade.actualProfitLoss());
+				profitLoss = Double.parseDouble(priceDetails.priceToString(trade.actualProfitLoss()));
 				profitLossPct = trade.formattedProfitLossPct();
-				profitLossReferenceCurrency = refPriceDetails.priceToString(trade.actualProfitLossInReferenceCurrency());
+				profitLossReferenceCurrency = Double.parseDouble(refPriceDetails.priceToString(trade.actualProfitLossInReferenceCurrency()));
 			}
-			minChangePct = trade.formattedMinChangePct();
-			maxChangePct = trade.formattedMaxChangePct();
-			minPrice = priceDetails.priceToString(trade.minPrice());
-			maxPrice = priceDetails.priceToString(trade.maxPrice());
+			minChangePct = trade.minChange();
+			maxChangePct = trade.maxChange();
+			minPrice = trade.minPrice();
+			maxPrice = trade.maxPrice();
 			ticks = trade.ticks();
 			exitReason = trade.exitReason();
 
@@ -159,31 +156,35 @@ public class OrderExecutionLine {
 	}
 
 	public String printMinChange() {
-		return isShort ? maxChangePct : minChangePct;
+		return isShort ? getFormattedMaxChangePct() : getFormattedMinChangePct();
 	}
 
 	public String printMaxChange() {
-		return isShort ? minChangePct : maxChangePct;
+		return isShort ? getFormattedMinChangePct() : getFormattedMaxChangePct();
 	}
 
 	public String printMaxPriceAndChange() {
-		return concat(maxPrice, printMaxChange());
+		return concat(getFormattedMaxPrice(), printMaxChange());
 	}
 
 	public String printMinPriceAndChange() {
-		return concat(maxPrice, printMinChange());
+		return concat(getFormattedMaxPrice(), printMinChange());
 	}
 
 	public String printLastPriceAndChange() {
-		return concat(price, priceChangePct);
+		return concat(getFormattedPrice(), getFormattedPriceChangePct());
+	}
+
+	private String getFormattedPriceChangePct() {
+		return priceChangePct;
 	}
 
 	public String printProfitLossAndChange() {
-		return concat(profitLoss, profitLossPct);
+		return concat(getFormattedProfitLoss(), profitLossPct);
 	}
 
 	public String printReferenceCurrencyProfitLossAndChange() {
-		return referenceCurrency + " " + concat(profitLossReferenceCurrency, profitLossPct);
+		return referenceCurrency + " " + concat(profitLossReferenceCurrency.toString(), profitLossPct);
 	}
 
 	public String printHoldingsAndReferenceCurrency() {
@@ -210,36 +211,160 @@ public class OrderExecutionLine {
 				", exitReason='" + exitReason + '\'' +
 				", ticks=" + ticks +
 				", fundSymbol='" + fundSymbol + '\'' +
-				", minPrice='" + minPrice + '\'' +
-				", minChangePct='" + minChangePct + '\'' +
-				", maxChangePct='" + maxChangePct + '\'' +
-				", maxPrice='" + maxPrice + '\'' +
-				", price='" + price + '\'' +
-				", averagePrice='" + averagePrice + '\'' +
-				", priceChangePct='" + priceChangePct + '\'' +
-				", quantity='" + quantity + '\'' +
+				", minPrice='" + getFormattedMinPrice() + '\'' +
+				", minChangePct='" + getFormattedMinChangePct() + '\'' +
+				", maxChangePct='" + getFormattedMaxChangePct() + '\'' +
+				", maxPrice='" + getFormattedMaxPrice() + '\'' +
+				", price='" + getFormattedPrice() + '\'' +
+				", averagePrice='" + getFormattedAveragePrice() + '\'' +
+				", priceChangePct='" + getFormattedPriceChangePct() + '\'' +
+				", quantity='" + getFormattedQuantity() + '\'' +
 				", referenceCurrency='" + referenceCurrency + '\'' +
 				", status=" + status +
 				", orderType=" + orderType +
-				", orderAmount='" + orderAmount + '\'' +
-				", executedQuantity='" + executedQuantity + '\'' +
-				", valueTransacted='" + valueTransacted + '\'' +
-				", freeBalance='" + freeBalance + '\'' +
-				", shortedQuantity='" + shortedQuantity + '\'' +
-				", marginReserve='" + marginReserve + '\'' +
-				", freeBalanceReferenceCurrency='" + freeBalanceReferenceCurrency + '\'' +
+				", orderAmount='" + getFormattedOrderAmount() + '\'' +
+				", executedQuantity='" + getFormattedExecutedQuantity() + '\'' +
+				", valueTransacted='" + getFormattedValueTransacted() + '\'' +
+				", freeBalance='" + getFormattedFreeBalance() + '\'' +
+				", shortedQuantity='" + getFormattedShortedQuantity() + '\'' +
+				", marginReserve='" + getFormattedMarginReserve() + '\'' +
+				", freeBalanceReferenceCurrency='" + getFormattedFreeBalanceReferenceCurrency() + '\'' +
 				", estimatedProfitLossPct='" + estimatedProfitLossPct + '\'' +
-				", profitLoss='" + profitLoss + '\'' +
+				", profitLoss='" + getFormattedProfitLoss() + '\'' +
 				", profitLossPct='" + profitLossPct + '\'' +
-				", profitLossReferenceCurrency='" + profitLossReferenceCurrency + '\'' +
+				", profitLossReferenceCurrency='" + profitLossReferenceCurrency.toString() + '\'' +
 				", holdings='" + holdings + '\'' +
 				", duration='" + duration + '\'' +
 				", orderFillPercentage='" + orderFillPercentage + '\'' +
 				", trigger=" + trigger +
-				", triggerPrice='" + triggerPrice + '\'' +
+				", triggerPrice='" + getFormattedTriggerPrice() + '\'' +
 				", fillPct=" + fillPct +
 				", isShort=" + isShort +
 				", isBuy=" + isBuy +
 				'}';
+	}
+
+
+	@Parsed(field = "executedQuantity")
+	public String getFormattedExecutedQuantity(){
+		SymbolPriceDetails priceDetails = trader.priceDetails();
+		return order == null ? null : priceDetails.quantityToString(order.getExecutedQuantity());
+	}
+
+	@Parsed(field = "minPrice")
+	public String getFormattedMinPrice(){
+		SymbolPriceDetails priceDetails = trader.priceDetails();
+
+		return trade == null ? null : priceDetails.priceToString(trade.minPrice());
+	}
+
+	@Parsed(field = "maxPrice")
+	public String getFormattedMaxPrice(){
+		SymbolPriceDetails priceDetails = trader.priceDetails();
+		return trade == null ? null : priceDetails.priceToString(trade.maxPrice());
+	}
+
+	@Parsed(field = "quantity")
+	public String getFormattedQuantity() {
+
+		SymbolPriceDetails priceDetails = this.trader.priceDetails();
+		return order == null ? null : priceDetails.quantityToString(order.getQuantity());
+	}
+
+	@Parsed(field = "averagePrice")
+	public String getFormattedAveragePrice(){
+		SymbolPriceDetails details = getAmountDetails();
+		return order == null || details == null? null : details.priceToString(order.getAveragePrice());
+	}
+
+	@Parsed(field = "price")
+	public String getFormattedPrice() {
+
+		if (order == null){
+			return null;
+		}
+		SymbolPriceDetails priceDetails = this.trader.priceDetails();
+		SymbolPriceDetails refPriceDetails = trader.referencePriceDetails();
+
+		SymbolPriceDetails amountDetails = fundSymbol.equals(referenceCurrency) ? refPriceDetails : priceDetails;
+		double priceAmount = order.getPrice() == 0.0 ? trader.latestCandle().close : order.getPrice();
+
+		return this.order.isBuy() ? amountDetails.priceToString(order.getPrice()) : priceDetails.priceToString(priceAmount);
+	}
+
+	@Parsed(field = "freeBalance")
+	public String getFormattedFreeBalance() {
+		if (order == null){
+			return null;
+		}
+		SymbolPriceDetails amountDetails = getAmountDetails();
+		return amountDetails != null ? amountDetails.priceToString(freeBalance) : null;
+	}
+
+	@Parsed(field = "freeBalanceReferenceCurrency")
+	public String getFormattedFreeBalanceReferenceCurrency() {
+		return freeBalanceReferenceCurrency.toString();
+	}
+
+	@Parsed(field = "shortedQuantity")
+	public String getFormattedShortedQuantity() {
+
+		SymbolPriceDetails priceDetails = this.trader.priceDetails();
+		return trade == null || order == null ? null : priceDetails.quantityToString(trader.balance(assetSymbol).getShorted());
+	}
+
+	@Parsed(field = "marginReserve")
+	public String getFormattedMarginReserve() {
+		if (order == null){
+			return null;
+		}
+		SymbolPriceDetails amountDetails = getAmountDetails();
+		Balance balance = trader.balanceOf(fundSymbol);
+		return amountDetails != null ? amountDetails.priceToString(balance.getMarginReserve(trader.assetSymbol())) : null;
+	}
+
+	private SymbolPriceDetails getAmountDetails() {
+		if (fundSymbol == null){
+			return null;
+		}
+		SymbolPriceDetails priceDetails = this.trader.priceDetails();
+		SymbolPriceDetails refPriceDetails = trader.referencePriceDetails();
+		return fundSymbol.equals(referenceCurrency) ? refPriceDetails : priceDetails;
+	}
+
+	@Parsed(field = "orderAmount")
+	public String getFormattedOrderAmount(){
+		SymbolPriceDetails details = getAmountDetails();
+		return order == null || details == null ? null : details.priceToString(orderAmount);
+	}
+
+	@Parsed(field = "valueTransacted")
+	public String getFormattedValueTransacted() {
+		if (order == null){
+			return null;
+		}
+		SymbolPriceDetails amountDetails = getAmountDetails();
+		return amountDetails != null ? amountDetails.priceToString(order.getTotalTraded()) : null;
+	}
+
+	@Parsed(field = "triggerPrice")
+	public String getFormattedTriggerPrice(){
+		SymbolPriceDetails priceDetails = this.trader.priceDetails();
+		return priceDetails.priceToString(triggerPrice);
+
+	}
+
+	@Parsed(field = "minChangePct")
+	public String getFormattedMinChangePct(){
+		return trade == null ? null : trade.formattedMinChangePct();
+	}
+
+	@Parsed(field = "maxChangePct")
+	public String getFormattedMaxChangePct(){
+		return trade == null ? null : trade.formattedMaxChangePct();
+	}
+
+	public String getFormattedProfitLoss(){
+		return profitLoss.toString();
 	}
 }

--- a/univocity-trader-core/src/main/java/com/univocity/trader/notification/OrderExecutionToLog.java
+++ b/univocity-trader-core/src/main/java/com/univocity/trader/notification/OrderExecutionToLog.java
@@ -1,8 +1,10 @@
 package com.univocity.trader.notification;
 
-import com.univocity.trader.account.*;
-import org.apache.commons.lang3.*;
-import org.slf4j.*;
+import com.univocity.trader.account.Order;
+import com.univocity.trader.account.Trade;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OrderExecutionToLog implements OrderListener {
 
@@ -29,7 +31,7 @@ public class OrderExecutionToLog implements OrderListener {
 			if (o.fillPct != 100.0) {
 				details += o.orderFillPercentage + " filled, ";
 			}
-			details += (o.isBuy ? "spent" : "sold") + " $" + o.valueTransacted + " " + o.fundSymbol;
+			details += (o.isBuy ? "spent" : "sold") + " $" + o.getFormattedValueTransacted() + " " + o.fundSymbol;
 			details += time;
 		}
 		return details;
@@ -40,13 +42,13 @@ public class OrderExecutionToLog implements OrderListener {
 			OrderExecutionLine o = new OrderExecutionLine(order, trade, trade.trader(), client);
 			String type = StringUtils.rightPad(o.operation, 5);
 
-			String quantity = o.quantity;
+			String quantity = o.getFormattedQuantity();
 			if (maxQuantityLength < quantity.length()) {
 				maxQuantityLength = quantity.length();
 			}
 			quantity = StringUtils.leftPad(quantity, maxQuantityLength);
 
-			String price = o.price;
+			String price = o.getFormattedPrice();
 			if (maxPriceLength < price.length()) {
 				maxPriceLength = price.length();
 			}
@@ -62,13 +64,13 @@ public class OrderExecutionToLog implements OrderListener {
 					details += " + " + printFillDetails(o) + ".";
 					if (order.getExecutedQuantity() != 0) {
 						if (order.isLongBuy()) {
-							details += " Worth $" + o.price + " " + o.fundSymbol + " (free $" + o.freeBalance + " " + o.fundSymbol;
+							details += " Worth $" + o.getFormattedPrice() + " " + o.fundSymbol + " (free $" + o.getFormattedFreeBalance() + " " + o.fundSymbol;
 							if (!o.fundSymbol.equals(o.referenceCurrency)) {
-								details += ", $" + o.freeBalanceReferenceCurrency + " " + o.referenceCurrency;
+								details += ", $" + o.getFormattedFreeBalanceReferenceCurrency() + " " + o.referenceCurrency;
 							}
 							details += ")";
 						} else if (order.isShortSell()) {
-							details += " Shorting total " + o.assetSymbol + " " + o.shortedQuantity + " (" + o.fundSymbol + " margin reserve: $" + o.marginReserve + ", free $" + o.freeBalance + ")";
+							details += " Shorting total " + o.assetSymbol + " " + o.getFormattedShortedQuantity() + " (" + o.fundSymbol + " margin reserve: $" + o.getFormattedMarginReserve() + ", free $" + o.getFormattedFreeBalance() + ")";
 						}
 					}
 				} else {
@@ -81,7 +83,7 @@ public class OrderExecutionToLog implements OrderListener {
 						details += " P/L " + o.printReferenceCurrencyProfitLossAndChange();
 					}
 
-					details += " Holdings $" + o.printHoldingsAndReferenceCurrency() + " (free $" + o.freeBalanceReferenceCurrency + ")";
+					details += " Holdings $" + o.printHoldingsAndReferenceCurrency() + " (free $" + o.getFormattedFreeBalanceReferenceCurrency() + ")";
 				} else {
 					details += " - PENDING     worth $" + o.printOrderAmountAndCurrency();
 


### PR DESCRIPTION
For some OrderExecutionListeners such as Google Sheet export, it makes sense to maintain the original data types so that the target can parse and format accordingly.