### PR TITLE
Increase connection resilience

### DIFF
--- a/univocity-trader-binance/src/main/java/com/univocity/trader/exchange/binance/KeepAliveUserDataStream.java
+++ b/univocity-trader-binance/src/main/java/com/univocity/trader/exchange/binance/KeepAliveUserDataStream.java
@@ -20,8 +20,8 @@ public class KeepAliveUserDataStream {
         this.listenKey = client.startUserDataStream();
         TimerTask task = new TimerTask() {
             public void run() {
+                client.ping();
                 client.keepAliveUserDataStream(listenKey);
-
             }
         };
         timer = new Timer("Keep-alive Timer", true);


### PR DESCRIPTION
Issue a client.ping() call on every keepAlive task. This seems to have finally quieted down spurious timeout exceptions during a buy event. Also retry for a few times before giving up on making a call.